### PR TITLE
Support for varying "add" labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <!-- statamic:hide -->
 
 ![Statamic 5](https://img.shields.io/badge/Statamic-5.0-FF269E?style=for-the-badge&link=https://statamic.com)
-[![Frontend Grid Fieldtype for Statamic on Packagist](https://img.shields.io/packagist/v/mitydigital/statamic-variable-number-fieldtype?style=for-the-badge)](https://packagist.org/packages/mitydigital/statamic-frontend-grid-fieldtype/stats)
+[![Frontend Grid Fieldtype for Statamic on Packagist](https://img.shields.io/packagist/v/mitydigital/statamic-frontend-grid-fieldtype?style=for-the-badge)](https://packagist.org/packages/mitydigital/statamic-frontend-grid-fieldtype/stats)
 
 ---
 

--- a/resources/lang/en/fieldtype.php
+++ b/resources/lang/en/fieldtype.php
@@ -16,6 +16,16 @@ return [
             'instructions' => 'If using a Scoped JS Driver, include your scope reference here. Leave blank otherwise.',
         ],
 
+        'add_row' => [
+            'display' => 'Add Row Label',
+            'instructions' => 'Optional. Will default to "Add". When a "Next" row label is provided, this will only be shown on empty grids.',
+        ],
+
+        'add_next_row' => [
+            'display' => 'Add "Next" Row Label',
+            'instructions' => 'Optional. Shown when there is at least 1 set in your grid. Will fall back to the "Add Row Label".',
+        ],
+
         'delete_row' => [
             'display' => 'Delete Row Label',
             'instructions' => 'Customize the label of the "Delete Row" button.',

--- a/resources/views/forms/fields/frontend_grid.antlers.html
+++ b/resources/views/forms/fields/frontend_grid.antlers.html
@@ -74,7 +74,8 @@
         <button @click.prevent="add"
                 :disabled="!canAddSet"
                 class="border border-gray-500 rounded py-1 px-5">
-            {{ add_row }}
+            <span x-show="sets.length === 0">{{ add_row }}</span>
+            <span x-cloak x-show="sets.length > 0">{{ add_next_row }}</span>
         </button>
     </div>
 </div>

--- a/src/Fieldtypes/FrontendGridFieldtype.php
+++ b/src/Fieldtypes/FrontendGridFieldtype.php
@@ -73,8 +73,13 @@ class FrontendGridFieldtype extends Fieldtype
                         'type' => 'integer',
                     ],
                     'add_row' => [
-                        'display' => __('Add Row Label'),
-                        'instructions' => __('statamic::fieldtypes.grid.config.add_row'),
+                        'display' => __('statamic-frontend-grid-fieldtype::fieldtype.config.add_row.display'),
+                        'instructions' => __('statamic-frontend-grid-fieldtype::fieldtype.config.add_row.instructions'),
+                        'type' => 'text',
+                    ],
+                    'add_next_row' => [
+                        'display' => __('statamic-frontend-grid-fieldtype::fieldtype.config.add_next_row.display'),
+                        'instructions' => __('statamic-frontend-grid-fieldtype::fieldtype.config.add_next_row.instructions'),
                         'type' => 'text',
                     ],
                     'delete_row' => [
@@ -180,7 +185,7 @@ class FrontendGridFieldtype extends Fieldtype
                 }
 
                 //if ($chk) {
-                    //dd($markup);
+                //dd($markup);
                 //}
 
                 if (false) {
@@ -241,6 +246,7 @@ class FrontendGridFieldtype extends Fieldtype
             'set_fields' => $setFields,
 
             'add_row' => $this->config('add_row', __('Add')),
+            'add_next_row' => $this->config('add_next_row', $this->config('add_row', __('Add'))),
             'delete_row' => $this->config('delete_row', __('Delete')),
         ];
     }
@@ -282,18 +288,18 @@ class FrontendGridFieldtype extends Fieldtype
 
         $fieldRules = Arr::get($this->field()->config(), 'validate', []);
 
-        if (!in_array('array', $fieldRules)) {
+        if (! in_array('array', $fieldRules)) {
             $fieldRules[] = 'array';
         }
 
-        $hasMin = collect($fieldRules)->filter(fn(string $rule) => Str::startsWith($rule, 'min:'))->count() ? true : false;
-        $hasMax = collect($fieldRules)->filter(fn(string $rule) => Str::startsWith($rule, 'max:'))->count() ? true : false;
+        $hasMin = collect($fieldRules)->filter(fn (string $rule) => Str::startsWith($rule, 'min:'))->count() ? true : false;
+        $hasMax = collect($fieldRules)->filter(fn (string $rule) => Str::startsWith($rule, 'max:'))->count() ? true : false;
 
-        if (!$hasMin && $minRows = Arr::get($this->field()->config(), 'min_rows', null)) {
+        if (! $hasMin && $minRows = Arr::get($this->field()->config(), 'min_rows', null)) {
             $fieldRules[] = 'min:'.$minRows;
         }
 
-        if (!$hasMax && $maxRows = Arr::get($this->field()->config(), 'max_rows', null)) {
+        if (! $hasMax && $maxRows = Arr::get($this->field()->config(), 'max_rows', null)) {
             $fieldRules[] = 'max:'.$maxRows;
         }
 


### PR DESCRIPTION
Adds optional support for "add" labels that change.

The default, when not provided, is simply "Add".

The "Add Row Label" is used when there are 0 sets.
The "Add Next Row Label" is used when there is at least 1 set.

If the "Add Next Row Label" is omitted, the "Add Row Label" (or default) will be used.